### PR TITLE
Add: Camera Component

### DIFF
--- a/assets/config.cfg
+++ b/assets/config.cfg
@@ -10,11 +10,11 @@ camera_fov:45.F;
 camera_nearplane:0.01F;
 camera_farplane:1000000.F;
 camera_eye_x:0.F;
-camera_eye_y:10.F;
-camera_eye_z:10.F;
+camera_eye_y:0.F;
+camera_eye_z:0.F;
 camera_target_x:0.F;
-camera_target_y:10.F;
-camera_target_z:0.F;
+camera_target_y:0.F;
+camera_target_z:1.F;
 
 [Window settings]
 window_width:720;

--- a/src/Camera.hpp
+++ b/src/Camera.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "glm/glm.hpp"
+#include "glm/gtc/matrix_transform.hpp"
+
+struct Camera
+{
+	float aspectRatio;
+	float fov;
+
+	glm::mat4 view;
+	glm::mat4 projection;
+	glm::mat4 invProjection;
+
+	Camera(float aspectRatio, float fov = 90.0f):
+		aspectRatio(aspectRatio), fov(fov), view(1.0f)
+	{
+		this->projection = glm::perspective(fov, aspectRatio, 0.01f, 10000.0f);
+		this->invProjection = glm::inverse(this->projection);
+	}
+};

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -13,6 +13,23 @@ Scene::~Scene()
 {
 }
 
+Camera* Scene::getMainCamera()
+{
+	Camera* cam = nullptr;
+	if (this->entityValid(this->mainCamera)) { cam = &this->getComponent<Camera>(this->mainCamera); }
+	return cam;
+}
+
+int Scene::getMainCameraID()
+{
+	return this->mainCamera;
+}
+
+void Scene::setMainCamera(int entity)
+{
+	if (this->hasComponents<Camera>(entity)) { this->mainCamera = entity; }
+}
+
 void Scene::updateSystems()
 {
 	for (auto it = this->systems.begin(); it != this->systems.end();)

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -2,6 +2,7 @@
 
 #include "System.hpp"
 #include "Transform.hpp"
+#include "Camera.hpp"
 
 #include <entt.hpp>
 #include <vector>
@@ -15,10 +16,15 @@ private:
 
 	entt::registry reg;
 	std::vector<System*> systems;
+	int mainCamera;
 
 public:
 	Scene(SceneHandler& sceneHandler);
 	virtual ~Scene();
+
+	Camera* getMainCamera();
+	int getMainCameraID();
+	void setMainCamera(int entity);
 
 	template <typename T, typename ...Args>
 	void createSystem(Args... args);

--- a/src/TestScene.cpp
+++ b/src/TestScene.cpp
@@ -5,6 +5,8 @@
 #include "glm/glm.hpp"
 #include "glm/gtx/string_cast.hpp"
 #include "MeshComponent.hpp"
+#include "Log.h"
+#include "Configurator.h"
 
 TestScene::TestScene(SceneHandler& sceneHandler)
 	: Scene(sceneHandler)
@@ -19,12 +21,17 @@ void TestScene::init()
 {
 	std::cout << "Test scene init" << std::endl;
 
+	// Camera
+	int camEntity = this->createEntity();
+	this->setComponent<Camera>(camEntity, 1.0f);
+	this->setMainCamera(camEntity);
+
 	// Create entity (already has transform)
 	this->testEntity = this->createEntity();
 
 	// Transform component
 	Transform& transform = this->getComponent<Transform>(this->testEntity);
-	transform.position = glm::vec3(0.F, 10.F, -100.F);
+	transform.position = glm::vec3(0.f, 0.f, 30.f);
 	transform.rotation = glm::vec3(-90.0f, 0.0f, 0.0f);
 	transform.scale = glm::vec3(10.0f, 5.0f, 5.0f);
 
@@ -38,7 +45,7 @@ void TestScene::init()
 
 	// Transform component
 	Transform& transform2 = this->getComponent<Transform>(this->testEntity2);
-	transform2.position = glm::vec3(20.F, 20.F, -100.F);
+	transform2.position = glm::vec3(20.f, 0.f, 30.f);
 	transform2.rotation = glm::vec3(-90.0f, 40.0f, 0.0f);
 	transform2.scale = glm::vec3(10.0f, 5.0f, 5.0f);
 
@@ -57,4 +64,11 @@ void TestScene::update()
 
 	Transform& transform2 = this->getComponent<Transform>(this->testEntity2);
 	transform2.position.x += Time::getDT();
+
+	if (this->entityValid(this->getMainCameraID()))
+	{
+		glm::vec3 moveVec = glm::vec3(Input::isKeyDown(Keys::A) - Input::isKeyDown(Keys::D), 0.0f, Input::isKeyDown(Keys::W) - Input::isKeyDown(Keys::S));
+		Transform& camTransform = this->getComponent<Transform>(this->getMainCameraID());
+		camTransform.position += moveVec * 25.0f * Time::getDT();
+	}
 }

--- a/src/Transform.hpp
+++ b/src/Transform.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "glm/glm.hpp"
-#include "glm/ext/matrix_transform.hpp"
+#include "glm/gtc/matrix_transform.hpp"
 
 struct Transform
 {
@@ -15,7 +15,7 @@ struct Transform
 		position(0.0f), rotation(0.0f), scale(1.0f), matrix(1.0f)
 	{ }
 
-	glm::vec3 right() { return glm::vec3(this->matrix[0]); }
-	glm::vec3 up() { return glm::vec3(this->matrix[1]); }
-	glm::vec3 forward() { return glm::vec3(this->matrix[2]); }
+	glm::vec3 right() { return glm::normalize(glm::vec3(this->matrix[0])); }
+	glm::vec3 up() { return glm::normalize(glm::vec3(this->matrix[1])); }
+	glm::vec3 forward() { return glm::normalize(glm::vec3(this->matrix[2])); }
 };

--- a/src/VulkanRenderer.cpp
+++ b/src/VulkanRenderer.cpp
@@ -547,6 +547,7 @@ void VulkanRenderer::draw(Scene* scene)
 
     // Get scene camera and update view matrix
     Camera* camera = scene->getMainCamera();
+    bool deleteCamera = false;
     if (camera)
     {
         Transform& transform = scene->getComponent<Transform>(scene->getMainCameraID());
@@ -558,9 +559,10 @@ void VulkanRenderer::draw(Scene* scene)
     }
     else
     {
-        Log::write("No main camera exists!");
+        Log::error("No main camera exists!");
         camera = new Camera((float)this->swapChainExtent.width / (float)this->swapChainExtent.height);
         camera->view = uboViewProjection.view;
+        deleteCamera = true;
     }
 
     unsigned int imageIndex = 0 ;
@@ -602,6 +604,7 @@ void VulkanRenderer::draw(Scene* scene)
     uboViewProjection.view = camera->view;
     uboViewProjection.projection = camera->projection;
     uboViewProjection.projection[1][1] *= -1;
+    if (deleteCamera) { delete camera; }
 
     /// Update the Uniform Buffers
     this->updateUniformBuffers(imageIndex);

--- a/src/VulkanRenderer.h
+++ b/src/VulkanRenderer.h
@@ -1,5 +1,7 @@
 
 #pragma once
+#define NOMINMAX
+
 #include <vulkan/vulkan.hpp>
 #include "Utilities.h"
 #include "Window.h"
@@ -18,6 +20,7 @@
 #endif 
 
 class Scene;
+class Camera;
 
 #include <functional>
 using stbi_uc = unsigned char;
@@ -182,7 +185,7 @@ private:
     void setupDebugMessenger();
     void createSurface();
     void createSwapChain();
-    void reCreateSwapChain();    
+    void reCreateSwapChain(Camera* camera);    
     void createRenderPass_Base();
     void createRenderPass_Imgui();
     void createDescriptorSetLayout();


### PR DESCRIPTION
Added a camera component that can be used on entities. The scene owns a main camera reference that is used in rendering. If there is no main camera, the renderer uses it's own backup.